### PR TITLE
Fix tests

### DIFF
--- a/find_attitude/find_attitude.py
+++ b/find_attitude/find_attitude.py
@@ -402,7 +402,7 @@ def find_matching_agasc_ids(stars, agasc_pairs_file, g_dist_match=None, toleranc
         logger.debug('g_geom_match: ')
         for n0, n1 in nx.edges(g_geom_match):
             ed = g_geom_match.get_edge_data(n0, n1)
-            logger.debug(n0, n1, ed)
+            logger.debug(f'{n0=} {n1=} {ed=}')
 
     out = []
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
 filterwarnings =
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-
+    ignore:`np.float` is a deprecated alias for the builtin `float`.:DeprecationWarning
+    ignore:`np.int` is a deprecated alias for the builtin `int`:DeprecationWarning
+    ignore:`np.object` is a deprecated alias for the builtin `object`:DeprecationWarning
+    ignore:'soft_unicode' has been renamed to 'soft_str':DeprecationWarning


### PR DESCRIPTION
## Description

Fix tests.  

They were failing due to the formatting of the debug print and if called with pytest without an `__init__.py` in the testing directory, these seemed to be running against the installed code instead of the local files.

See also #17 for more on the exception.

## Testing

- [x] Passes unit tests called with pytest from linux HEAD flight and test
- [n/a] Functional testing

