### PR TITLE
Fix logging statement that apparently stopped working at some point

### DIFF
--- a/find_attitude/find_attitude.py
+++ b/find_attitude/find_attitude.py
@@ -402,7 +402,7 @@ def find_matching_agasc_ids(stars, agasc_pairs_file, g_dist_match=None, toleranc
         logger.debug('g_geom_match: ')
         for n0, n1 in nx.edges(g_geom_match):
             ed = g_geom_match.get_edge_data(n0, n1)
-            logger.debug(n0, n1, ed)
+            logger.debug(f'{n0=} {n1=} {ed=}')
 
     out = []
 


### PR DESCRIPTION
## Description

There is a debug logging statement that passes three arguments, two integers and a dict. At some point this must have been working but now this ends up throwing an exception. The fix is to make the logger args into a single string.

```
find_attitude/tests/test_find_attitude.py:242: in check_at_time
    solutions = find_attitude_solutions(stars)
find_attitude/find_attitude.py:567: in find_attitude_solutions
    agasc_id_star_maps = find_all_matching_agasc_ids(stars['YAG'], stars['ZAG'], stars['MAG_ACA'],
find_attitude/find_attitude.py:442: in find_all_matching_agasc_ids
    agasc_id_star_maps = find_matching_agasc_ids(stars, agasc_pairs_file,
find_attitude/find_attitude.py:405: in find_matching_agasc_ids
    logger.debug(n0, n1, ed)
../logging/__init__.py:1434: in debug
    self._log(DEBUG, msg, args, **kwargs)
../logging/__init__.py:1589: in _log
    self.handle(record)
../logging/__init__.py:1599: in handle
    self.callHandlers(record)
../logging/__init__.py:1661: in callHandlers
    hdlr.handle(record)
../logging/__init__.py:954: in handle
    self.emit(record)
_pytest/logging.py:331: in emit
    super().emit(record)
pyyaks/logger.py:62: in emit_newline_optional
    handler.handleError(record)
pyyaks/logger.py:49: in emit_newline_optional
    msg = handler.format(record)
../logging/__init__.py:929: in format
    return fmt.format(record)
_pytest/logging.py:92: in format
    return super().format(record)
../logging/__init__.py:668: in format
    record.message = record.getMessage()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <LogRecord: find_attitude, 10, /proj/sot/ska3/test/lib/python3.8/site-packages/find_attitude/find_attitude.py, 405, "858557144">

    def getMessage(self):
        """
        Return the message for this LogRecord.
    
        Return the message for this LogRecord after merging any user-supplied
        arguments with the message.
        """
        msg = str(self.msg)
        if self.args:
>           msg = msg % self.args
E           TypeError: not all arguments converted during string formatting

../logging/__init__.py:373: TypeError
```

## Testing

- [x] Passes unit tests on HEAD linux
- [n/a] Functional testing
