### PR TITLE
Silence the sherpa warning about DS9 not being available

### DIFF
--- a/find_attitude/find_attitude.py
+++ b/find_attitude/find_attitude.py
@@ -464,6 +464,13 @@ def find_attitude_for_agasc_ids(yags, zags, agasc_id_star_map):
     """
     global yagzag
 
+    # Squelch the useless warning below prior to import. Since this application
+    # does not dealing with image data we don't worry about silencing these.
+    # WARNING: imaging routines will not be available,
+    # failed to import sherpa.image.ds9_backend due to
+    # 'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
+    logging.getLogger('sherpa.image').setLevel(logging.ERROR)
+
     from sherpa import ui
     import agasc
     from Quaternion import Quat


### PR DESCRIPTION
## Description

When importing `sherpa.ui` it always checks for the presence of the `ds9` app in the path, even if it is irrelevant to the fitting task.
```
WARNING: imaging routines will not be available,
failed to import sherpa.image.ds9_backend due to
 'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
```
This shows up in `ska_testr` outputs and triggers a failure because of the `WARNING`. This is emitted as a `logger.warning` not a Python warning.

This PR sets the logging level for the that logger to `logging.ERROR` so the warning message is not emitted.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing

Ran `pytest find_attitude -v -k test_multiple_solutions -s` with and without the patch.
- With the patch no warning is seen in the output
- Without the patch the usual warning is seen.

A more direct test is here:
```
$ ipython
In [1]: import logging
In [2]: logger = logging.getLogger('sherpa.image')
In [3]: logger.setLevel(logging.ERROR)
In [4]: import sherpa.image
In [5]:  # No warning!

$ ipython
In [1]: import sherpa.image
WARNING: imaging routines will not be available, 
failed to import sherpa.image.ds9_backend due to 
'RuntimeErr: DS9Win unusable: Could not find ds9 on your PATH'
```