### PR TITLE
Update test to pass with agasc 1p8 present

### DIFF
--- a/find_attitude/tests/conftest.py
+++ b/find_attitude/tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import agasc
+import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/find_attitude/tests/conftest.py
+++ b/find_attitude/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+import agasc
+
+
+@pytest.fixture(autouse=True)
+def proseco_agasc_rc(monkeypatch):
+    agasc_file = agasc.get_agasc_filename("proseco_agasc_*", allow_rc=True)
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
+
+
+@pytest.fixture()
+def proseco_agasc_1p7(monkeypatch):
+    agasc_file = agasc.get_agasc_filename("proseco_agasc_*", version="1p7")
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)

--- a/find_attitude/tests/test_find_attitude.py
+++ b/find_attitude/tests/test_find_attitude.py
@@ -165,6 +165,7 @@ def check_output(solutions, stars, ra, dec, roll):
 
 
 def test_ra_dec_roll(
+    proseco_agasc_1p7,
     ra=115.770455413,
     dec=-77.6580358662,
     roll=86.4089128685,


### PR DESCRIPTION
## Description

Pin a test at 1p7 and set rest for agasc1p8 via rc

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes test not passing with agasc 1p8.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
jeanconn-fido> git rev-parse HEAD
677dc69c74117502baf8aa3e1a08e372d559637c
jeanconn-fido> pytest --pdb
================================================================== test session starts ==================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 6 items                                                                                                                                       

find_attitude/tests/test_find_attitude.py .....4s.                                                                                                  [100%]

============================================================= 6 passed in 158.32s (0:02:38) =============================================================
jeanconn-fido> export AGASC_DIR=/proj/sot/ska/data/agasc/rc
jeanconn-fido> pytest --pdb
================================================================== test session starts ==================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 6 items                                                                                                                                       

find_attitude/tests/test_find_attitude.py ......                                                                                                  [100%]

============================================================= 6 passed in 152.31s (0:02:32
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
