### PR TITLE
Constrain `test_ra_dec_roll` regression test to a specific date

### DIFF
--- a/find_attitude/tests/test_find_attitude.py
+++ b/find_attitude/tests/test_find_attitude.py
@@ -415,11 +415,15 @@ def test_ra_dec_roll(
     sigma_1axis=0.4,
     sigma_mag=0.2,
 ):
+    """Regression test at a specific attitude and date"""
     global stars, agasc_id_star_maps, g_geom_match, g_dist_match, solutions
     stars = get_stars(
         ra, dec, roll, sigma_1axis=sigma_1axis, sigma_mag=sigma_mag, brightest=brightest
     )
-    solutions = find_attitude_solutions(stars, tolerance=2.5)
+    # Enforce the date constraint and remove the default off_nom_roll constraint.
+    constraints = Constraints(date="2024-08-28", off_nom_roll_max=None)
+
+    solutions = find_attitude_solutions(stars, tolerance=2.5, constraints=constraints)
     check_output(solutions, stars, ra, dec, roll)
     summary = solutions[0]["summary"]
     assert summary.pformat_all() == [


### PR DESCRIPTION
## Description

The `test_ra_dec_roll` regression test includes a star with high-enough proper motion to start failing after a short time. The check of the final summary output looks for stability at the 0.01 arcsec level. 

This PR constrains the test date to that of #32 so that the test should always pass.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #34

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  find_attitude git:(fix-regression-test-again-#34) env PYTHONPATH=/Users/aldcroft/git/ska_helpers:/Users/aldcroft/git/ska_sun pytest
=============================================== test session starts ================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 24 items                                                                                                 

find_attitude/tests/test_find_attitude.py ........................                                           [100%]

=============================================== 24 passed in 58.70s ================================================
(ska3) ➜  find_attitude git:(fix-regression-test-again-#34) git rev-parse HEAD
950622081e2191feed41ebffe5f6e6e0643c1d6b
```

Independent check of unit tests by Jean
- [x] Mac
```
(ska3-flight-accel) flame:find_attitude jean$ git rev-parse HEAD
950622081e2191feed41ebffe5f6e6e0643c1d6b
(ska3-flight-accel) flame:find_attitude jean$ pytest
============================================================= test session starts ==============================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 24 items                                                                                                                             

find_attitude/tests/test_find_attitude.py ........................                                                                       [100%]

============================================================= 24 passed in 54.87
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
I confirmed that `test_ra_dec_roll` was failing locally prior to the fix.
