### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/find_attitude/tests/test_find_attitude.py
+++ b/find_attitude/tests/test_find_attitude.py
@@ -426,7 +426,7 @@ def test_ra_dec_roll(
     solutions = find_attitude_solutions(stars, tolerance=2.5, constraints=constraints)
     check_output(solutions, stars, ra, dec, roll)
     summary = solutions[0]["summary"]
-    assert summary.pformat_all() == [
+    assert summary.pformat() == [
         " AGASC_ID     RA      DEC      YAG    YAG_ERR   ZAG    ZAG_ERR MAG_ACA MAG_ERROR  m_yag    m_zag   m_mag   dy    dz   dr  m_agasc_id",
         "---------- -------- -------- -------- ------- -------- ------- ------- --------- -------- -------- ----- ----- ----- ---- ----------",
         "1229590664 113.9040 -75.5443   277.57    0.34  1697.60   -0.19    7.16     -0.27   277.38  1697.49  7.42  0.19  0.11 0.21 1229590664",
@@ -514,7 +514,7 @@ def test_get_stars_from_table():
 @pytest.mark.skipif(not HAS_MAUDE, reason="maude not available")
 def test_get_stars_from_maude():
     stars = get_stars_from_maude("2024:001:12:00:00", dt=12.0)
-    assert stars.pformat_all() == [
+    assert stars.pformat() == [
         "slot   YAG      ZAG    MAG_ACA",
         "---- -------- -------- -------",
         "   0    39.69 -1882.49    7.31",


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
